### PR TITLE
Remove "Login Text" language setting

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -67,12 +67,6 @@
       },
       {
         "type": "text",
-        "id": "language_login",
-        "label": "Login Text",
-        "default": "Login"
-      },
-      {
-        "type": "text",
         "id": "language_logout",
         "label": "Logout Text",
         "default": "Logout"

--- a/snippets/user_menu.liquid
+++ b/snippets/user_menu.liquid
@@ -1,8 +1,4 @@
-{% if current_site_user %}
   <a href="/library" kjb-settings-id="{{ language_library }}">{{ settings.language_library }}</a>
   <span kjb-settings-id="{{ language_settings }}">{{ settings.language_settings | member_settings_link }}</span>
   <span kjb-settings-id="{{ language_logout }}">{{ settings.language_logout | member_logout_link }}</span>
   <img src="{{ current_site_user | avatar_url }}" kjb-settings-id="{{ 'show_user_menu' | settings_id: section: section }}"/>
-{% else %}
-  <span kjb-settings-id="{{ language_login }}">{{ settings.language_login | member_login_link }}</span>
-{% endif %}


### PR DESCRIPTION
Isn't hooked up to anything and is controlled at the site/LP level
<img width="1451" alt="Cornerstone Prod - get rid of login text" src="https://user-images.githubusercontent.com/17749903/54317384-394de180-45a0-11e9-8eb0-2f7c295cf6ae.png">
