### PR TITLE
"Show Header" isnt linked to setting location

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -3,7 +3,7 @@
   it clickable in the theme editor with a kjb-settings-id
 -->
 {% if section.settings.show_header %}
-  <div class="header">
+  <div class="header" kjb-settings-id="{{ 'show_header' | settings_id: section: section }}">
     <div class="container">
       <div class="media align-middle">
         <strong>{{ current_product.title }}</strong>


### PR DESCRIPTION
<img width="1452" alt="Cornerstone Prod - Show header setting linkage" src="https://user-images.githubusercontent.com/17749903/54317325-0f94ba80-45a0-11e9-90bb-fdc7591bcde5.png">
