### PR TITLE
User menu text settings aren't linked to setting locations

### DIFF
--- a/snippets/user_menu.liquid
+++ b/snippets/user_menu.liquid
@@ -1,8 +1,8 @@
 {% if current_site_user %}
-  <a href="/library" kjb-settings-id="{{ language_library }}">{{ settings.language_library }}</a>
-  <span kjb-settings-id="{{ language_settings }}">{{ settings.language_settings | member_settings_link }}</span>
-  <span kjb-settings-id="{{ language_logout }}">{{ settings.language_logout | member_logout_link }}</span>
+  <a href="/library" kjb-settings-id="{{ 'language_library' }}">{{ settings.language_library }}</a>
+  <span kjb-settings-id="{{ 'language_settings' }}">{{ settings.language_settings | member_settings_link }}</span>
+  <span kjb-settings-id="{{ 'language_logout' }}">{{ settings.language_logout | member_logout_link }}</span>
   <img src="{{ current_site_user | avatar_url }}" kjb-settings-id="{{ 'show_user_menu' | settings_id: section: section }}"/>
 {% else %}
-  <span kjb-settings-id="{{ language_login }}">{{ settings.language_login | member_login_link }}</span>
+  <span kjb-settings-id="{{ 'language_login' }}">{{ settings.language_login | member_login_link }}</span>
 {% endif %}


### PR DESCRIPTION
<img width="1454" alt="Cornerstone Prod - Language linkage" src="https://user-images.githubusercontent.com/17749903/54317206-cc3a4c00-459f-11e9-91fe-e7ae0ffa312f.png">
